### PR TITLE
Fixes #15

### DIFF
--- a/scripts/missing_lines.py
+++ b/scripts/missing_lines.py
@@ -6,7 +6,7 @@ from coverage import coverage
 def missing_lines(cov_file, cov_config, fname):
   cov = coverage(data_file=cov_file, config_file=cov_config)
   cov.load()
-  if cov.omit_match and cov.omit_match.match(fname):
+  if getattr(cov, 'omit_match', None) and cov.omit_match.match(fname):
     sys.stderr.write('Omitted file.\n')
     sys.exit(1)
 


### PR DESCRIPTION
In https://github.com/nedbat/coveragepy/commit/bd613312d29b21b3bce5bb6f7c6561244a6c6830 the `omit_match` method was hidden behind an `inorout` attribute (since renamed `_inorout`) which is not initialised without calling the `Coverage.start` method which will "Start measuring code coverage".

This patch performs a more tolerant check for `cov.omit_match` that won't error if it doesn't exist.

Having tested this change locally, it allows PyCover to work with Coverage 5.